### PR TITLE
QTMA to MIDI Conversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.pyc
+.DS_Store

--- a/delv/sound.py
+++ b/delv/sound.py
@@ -30,8 +30,6 @@ from util import bitstruct_pack, bits_pack,bits_of
 import array
 import cStringIO as StringIO
 
-import pdb #TODO remove
-
 class SoundError(Exception): pass
 
 class Sound(store.Store):

--- a/delv/sound.py
+++ b/delv/sound.py
@@ -297,7 +297,7 @@ class Music(Sound):
                 subtype = bits_of(footer, 14, 2)
                 event_length2 = bits_of(footer, 16,16)
                 if event_length != event_length2:
-                    raise MusicError, "Failed QTMA validity check: General Event at", self.src.tell()
+                    raise MusicError, "Failed QTMA validity check: General Event at ", self.src.tell()
                 # pass data length validity check, move cursor to read data
                 next_op = self.src.tell()
                 self.src.seek(data_offs)
@@ -306,16 +306,16 @@ class Music(Sound):
                     self.channels[part] = midi_channel
                 elif subtype == GEN_PART_KEY: # Detect key changes, not using
                     value = self.src.readb(next_op - data_offs - 4) # data chunk is everything from start to next op (-4 bytes of end of gen event)
-                    print "General: KEY CHANGE ", part, binascii.hexlify(value), self.src.tell()
+                    # print "General: KEY CHANGE ", part, binascii.hexlify(value), self.src.tell()
                 elif subtype == GEN_TUNE_DIFF: # sequence with tune difference, not using # TODO: maybe support tune diff?
                     # tune diffs appear to be tiny in Cythera, very little reason to include
                     # tuning even less widely supported than pitch bend, which varies greatly among synths itself
                     # given the lack of support, difficulty of using with the library, and seemingly tiny impact -- not using tune diffs now
                     value = self.src.readb(next_op - data_offs - 4)
-                    print "General: TUNE DIFF ", part, binascii.hexlify(value), self.src.tell()
+                    # print "General: TUNE DIFF ", part, binascii.hexlify(value), self.src.tell()
                 elif subtype == GEN_USED_NOTES: # Note used list is not necessary (probably used for QT pre-buffering), not using
                     value = self.src.readb(next_op - data_offs - 4)
-                    print "General: NOTES USED ", part, binascii.hexlify(value), self.src.tell()
+                    # print "General: NOTES USED ", part, binascii.hexlify(value), self.src.tell()
                 elif subtype == GEN_NOTE_REQUEST: # Set instrument number
                     nrflags = self.src.read_uint8() # control behavior if exact instrument not found in qt synth: either play best match or nothing
                     reserved = self.src.read_uint8() # unused
@@ -327,12 +327,9 @@ class Music(Sound):
                     instrument_name = self.src.read_str31()
                     instrument_number = self.src.read_uint32()
                     gm_number = self.src.read_uint32()
-                    #print "\tNote request", nrflags, reserved,polyphony,
-                    #print typical,repr(synthesizer_type),synthesizer_name,
-                    #print instrument_name,instrument_number,gm_number
                     self.instruments[part] = gm_number # midi instrument num; really nothing else useful in midi, all qt synth controls
                 else:
-                    print "Unsupported General Event subtype %d for part %d at %d"%(subtype,part,self.src.tell())
+                    raise MusicError, "Unsupported General Event subtype %d for part %d at %d"%(subtype,part,self.src.tell())
                 # Restore cursor for next op after processing general event and data
                 self.src.seek(next_op)
             elif t4 == T4_ECONTROL: # Extended control, not needed for Cythera? not using
@@ -342,7 +339,7 @@ class Music(Sound):
                     raise MusicError, "Failed QTMA validity check: Econtrol Event at", self.src.tell()
                 controller = bits_of(tail, 14, 2)
                 value = bits_of(tail, 16, 16)
-                print "Extended Controller ", part, controller, value, self.src.tell()
+                # print "Extended Controller ", part, controller, value, self.src.tell()
             elif t4 == T4_ENOTE:
                 tail = self.src.readb(4)
                 part = bits_of(command, 12, 4)
@@ -355,14 +352,14 @@ class Music(Sound):
             elif t3 == T3_MARKER: # Marker, not needed?  not using; can use rests/notes/enotes to increment time, no need for markers
                 subtype = bits_of(command, 8, 8)
                 value = bits_of(command, 16, 16)
-                if subtype == MARK_END:
-                    print "Marker: END " ,value, self.src.tell()
-                elif subtype == MARK_BEAT:
-                    print  "Marker: BEAT " ,value, self.src.tell()
-                elif subtype == MARK_TEMPO:
-                    print "Marker: TEMPO " ,value, self.src.tell()
-                else:
-                    print "Unsupported Marker Event subtype %d with value %d at %d"%(subtype,value,self.src.tell())
+                # if subtype == MARK_END:
+                #     print "Marker: END " ,value, self.src.tell()
+                # elif subtype == MARK_BEAT:
+                #     print  "Marker: BEAT " ,value, self.src.tell()
+                # elif subtype == MARK_TEMPO:
+                #     print "Marker: TEMPO " ,value, self.src.tell()
+                # else:
+                #     print "Unsupported Marker Event subtype %d with value %d at %d"%(subtype,value,self.src.tell())
             elif t3 == T3_CONTROL:
                 part = bits_of(command, 5, 3)
                 controller = bits_of(command, 8, 8)
@@ -408,7 +405,7 @@ class Music(Sound):
                     new_value = bits_of(command,8,16) # qtma appears to only use the upper 8 bits of the value; not clear from docs
                     self.qtma_commands.append(['reverb',part,new_value,0,0])
                 else:
-                    print "Unsupported Controller Event controller type %d for part %d with value %d at %d"%(controller,part,value,self.src.tell())
+                    raise MusicError, "Unsupported Controller Event controller type %d for part %d with value %d at %d"%(controller,part,value,self.src.tell())
             elif t3 == T3_NOTE:
                 part = bits_of(command, 5, 3)
                 pitch = bits_of(command, 6,8) + 32 # 32 bit offset in qtma
@@ -419,7 +416,7 @@ class Music(Sound):
                 duration = bits_of(command, 24, 8)
                 self.qtma_commands.append(["rest",0,0,0,duration])
             else:
-                print "Unknown event ",("%02X "*4)%tuple(command), self.src.tell()
+                raise MusicError, "Unknown event ",("%02X "*4)%tuple(command), self.src.tell()
         # self.src.seek(body_offset)
         # Before handling QTMA events, must ensure coherence of tracks for MIDI formatting; MIDI count needs to be consecutive
         # Find the max track value, and make sure there are at least empty tracks to avoid track count errors with MIDI

--- a/delv/sound.py
+++ b/delv/sound.py
@@ -297,7 +297,7 @@ class Music(Sound):
                 subtype = bits_of(footer, 14, 2)
                 event_length2 = bits_of(footer, 16,16)
                 if event_length != event_length2:
-                    raise MusicError, "Failed QTMA validity check: General Event at ", self.src.tell()
+                    raise MusicError, "Failed QTMA validity check: General Event at ",self.src.tell()
                 # pass data length validity check, move cursor to read data
                 next_op = self.src.tell()
                 self.src.seek(data_offs)
@@ -336,7 +336,7 @@ class Music(Sound):
                 tail = self.src.readb(4)
                 part = bits_of(command, 12, 4)
                 if bits_of(tail, 2, 0) != 2:
-                    raise MusicError, "Failed QTMA validity check: Econtrol Event at", self.src.tell()
+                    raise MusicError, "Failed QTMA validity check: Econtrol Event at ", self.src.tell()
                 controller = bits_of(tail, 14, 2)
                 value = bits_of(tail, 16, 16)
                 # print "Extended Controller ", part, controller, value, self.src.tell()
@@ -345,7 +345,7 @@ class Music(Sound):
                 part = bits_of(command, 12, 4)
                 pitch = bits_of(command, 15, 17)
                 if bits_of(tail, 2, 0) != 2:
-                    raise MusicError, "Failed QTMA validity check: Enote Event at", self.src.tell()
+                    raise MusicError, "Failed QTMA validity check: Enote Event at ", self.src.tell()
                 velocity = bits_of(tail, 7, 3)
                 duration = bits_of(tail, 22, 10)
                 self.qtma_commands.append(["enote",part,pitch,velocity,duration])
@@ -416,7 +416,7 @@ class Music(Sound):
                 duration = bits_of(command, 24, 8)
                 self.qtma_commands.append(["rest",0,0,0,duration])
             else:
-                raise MusicError, "Unknown event ",("%02X "*4)%tuple(command), self.src.tell()
+                raise MusicError, "Unknown event %s at %d"%(binascii.hexlify(command),self.src.tell())
         # self.src.seek(body_offset)
         # Before handling QTMA events, must ensure coherence of tracks for MIDI formatting; MIDI count needs to be consecutive
         # Find the max track value, and make sure there are at least empty tracks to avoid track count errors with MIDI

--- a/delv/sound.py
+++ b/delv/sound.py
@@ -29,6 +29,7 @@ import util, archive, store
 from util import bitstruct_pack, bits_pack,bits_of
 import array
 import cStringIO as StringIO
+import binascii
 
 class SoundError(Exception): pass
 
@@ -99,14 +100,40 @@ class SoundSND(Sound):
 
 class MusicError(Exception): pass
 
+# Primary command types
+# type.3 : 3 bit part types
+T3_REST = 0 # 4 byte len
+T3_NOTE = 1 # 4 byte len
+T3_CONTROL = 2 # 4 byte len
+T3_MARKER = 3 # 4 byte len
+# type.4 : 4 bit part types
+T4_ENOTE = 9 # 8 byte len
+T4_ECONTROL = 10 # 8 byte len
+T4_GENERAL = 15 # variable len
+# Subtype command types
+# T3_CONTROL event controllers
+CON_MOD = 1 # kControllerModulationWheel
+CON_VOL = 7 # kControllerVolume
+CON_PAN = 10 # kControllerPan, more commonly used than kControllerBalance for handling L/R balance
+CON_PITCH = 32 # kControllerPitchBend
+CON_PRESS = 33 # kControllerAfterTouch or channel pressure
+CON_SUSTAIN = 64 # kControllerSustain, positive for on, 0 for off (64 and 64 in midi, respectively)
+CON_REVERB = 91 # kControllerReverb, 0-127 in midi
+# T3_MARKER event subtypes
+MARK_END = 0
+MARK_BEAT = 1
+MARK_TEMPO = 2
+# T4_GENERAL event subtypes
+GEN_NOTE_REQUEST = 1
+GEN_PART_KEY = 4
+GEN_TUNE_DIFF = 5
+GEN_MIDI_CHANNEL = 8
+GEN_USED_NOTES = 11
+# Synth types
 MUSIC_COMPONENT_TYPE = 'musi'
 SOFT_SYNTH_COMPONENT_SUBTYPE = 'ss  '
 GM_SYNTH_COMPONENT_SUBTYPE = 'gm  '
-NOTE_REQUEST = 1
-PART_KEY = 4
-MIDI_CHANNEL = 8
-USED_NOTES = 11
-GENERAL_EVENT = 0xF
+# GM instrument mapping
 INSTRUMENT_NAMES = """Acoustic Grand Piano
 Bright Acoustic Piano 
 Electric Grand Piano
@@ -240,8 +267,8 @@ class Music(Sound):
     SxCD = 1
     TxCD = 0
     def __init__(self, src=None):
-        self.parts = {}
-        self.channels = {}
+        self.instruments = {} # instruments used, maps directly to midi instruments
+        self.channels = {} # channels, 10 is drums
         self.qtma_commands = []
         self.midi_commands = []
         self.flags = [0,1,1] # no idea what these do, if anything
@@ -249,16 +276,18 @@ class Music(Sound):
 
     def load_from_file(self, src):
         self.src = util.BinaryHandler(src)
-        body_offset = self.src.read_uint32()
+        body_offset = self.src.read_uint32() # body_offset tells when the general commands stop and others begin; may not need it, just read through
         musi = self.src.read(4)
         if musi != MUSIC_COMPONENT_TYPE: 
             raise ValueError, "%s is not a music resource"%src
         self.flags = [self.src.read_uint32() for _ in xrange(3)]
  
-        while self.src.tell() < body_offset:
+        # while self.src.tell() < body_offset:
+        while not self.src.eof():
             command = self.src.readb(4)
-            operation = bits_of(command, 4, 0)
-            if operation == GENERAL_EVENT:
+            t4 = bits_of(command, 4, 0)
+            t3 = bits_of(command, 3, 0)
+            if t4 == T4_GENERAL:
                 part = bits_of(command, 12, 4)
                 event_length = bits_of(command, 16, 16)
                 data_len = (event_length-2)*4
@@ -268,27 +297,32 @@ class Music(Sound):
                 subtype = bits_of(footer, 14, 2)
                 event_length2 = bits_of(footer, 16,16)
                 if event_length != event_length2:
-                    raise MusicError, "Failed QTMA validity check."
-                #print "General", part, event_length, subtype
-                if subtype == MIDI_CHANNEL: # Need to know if MIDI channel is 10 (percussion) since changes behavior
-                    next_op = self.src.tell()
-                    self.src.seek(data_offs)
+                    raise MusicError, "Failed QTMA validity check: General Event at", self.src.tell()
+                # pass data length validity check, move cursor to read data
+                next_op = self.src.tell()
+                self.src.seek(data_offs)
+                if subtype == GEN_MIDI_CHANNEL: # Need to know if MIDI channel is 10 (percussion) since changes behavior
                     midi_channel = self.src.read_uint32()
                     self.channels[part] = midi_channel
-                    self.src.seek(next_op)
-                elif subtype == PART_KEY: # Detect key changes
-                    continue # Not used in Cythera's case, but may be important in general QTMA to MIDI conversion
-                elif subtype == USED_NOTES: # Note used list is not necessary (probably used for QT pre-buffering)
-                    continue
-                elif subtype == NOTE_REQUEST: # Set instrument number
-                    next_op = self.src.tell()
-                    self.src.seek(data_offs)
-                    nrflags = self.src.read_uint8()
-                    reserved = self.src.read_uint8()
-                    polyphony = self.src.read_uint16()
-                    typical = self.src.read_fixed16()
+                elif subtype == GEN_PART_KEY: # Detect key changes, not using
+                    value = self.src.readb(next_op - data_offs - 4) # data chunk is everything from start to next op (-4 bytes of end of gen event)
+                    print "General: KEY CHANGE ", part, binascii.hexlify(value), self.src.tell()
+                elif subtype == GEN_TUNE_DIFF: # sequence with tune difference, not using # TODO: maybe support tune diff?
+                    # tune diffs appear to be tiny in Cythera, very little reason to include
+                    # tuning even less widely supported than pitch bend, which varies greatly among synths itself
+                    # given the lack of support, difficulty of using with the library, and seemingly tiny impact -- not using tune diffs now
+                    value = self.src.readb(next_op - data_offs - 4)
+                    print "General: TUNE DIFF ", part, binascii.hexlify(value), self.src.tell()
+                elif subtype == GEN_USED_NOTES: # Note used list is not necessary (probably used for QT pre-buffering), not using
+                    value = self.src.readb(next_op - data_offs - 4)
+                    print "General: NOTES USED ", part, binascii.hexlify(value), self.src.tell()
+                elif subtype == GEN_NOTE_REQUEST: # Set instrument number
+                    nrflags = self.src.read_uint8() # control behavior if exact instrument not found in qt synth: either play best match or nothing
+                    reserved = self.src.read_uint8() # unused
+                    polyphony = self.src.read_uint16() # max voices for quicktime synth
+                    typical = self.src.read_fixed16() # general num voices for volume control in qt synth
                     _align = self.src.read_uint16()
-                    synthesizer_type = self.src.read(4)
+                    synthesizer_type = self.src.read(4) # all the next few are for instrument and synth type
                     synthesizer_name = self.src.read_str31()
                     instrument_name = self.src.read_str31()
                     instrument_number = self.src.read_uint32()
@@ -296,64 +330,117 @@ class Music(Sound):
                     #print "\tNote request", nrflags, reserved,polyphony,
                     #print typical,repr(synthesizer_type),synthesizer_name,
                     #print instrument_name,instrument_number,gm_number
-                    self.parts[part] = gm_number
-                    self.src.seek(next_op)
+                    self.instruments[part] = gm_number # midi instrument num; really nothing else useful in midi, all qt synth controls
                 else:
-                    raise MusicError, "Unknown QTMA general subtype %d"%subtype
-            elif operation == 0x6: # End (marker event)
-                #print "End    ", self.src.tell()
-                break
-            else:
-                raise MusicError, "Unrecognized op, 0x%X@%d"%(
-                    operation, self.src.tell()-4)
-        self.src.seek(body_offset)
-        # Before handling QTMA events, must ensure coherence of tracks for MIDI formatting
-        # Find the max track value, and make sure there are at least empty tracks to avoid track count errors with MIDI
-        for i in range(max(list(self.parts))):
-            if i not in self.parts:
-                if i > 0:
-                    self.parts[i] = self.parts[i-1]
+                    print "Unsupported General Event subtype %d for part %d at %d"%(subtype,part,self.src.tell())
+                # Restore cursor for next op after processing general event and data
+                self.src.seek(next_op)
+            elif t4 == T4_ECONTROL: # Extended control, not needed for Cythera? not using
+                tail = self.src.readb(4)
+                part = bits_of(command, 12, 4)
+                if bits_of(tail, 2, 0) != 2:
+                    raise MusicError, "Failed QTMA validity check: Econtrol Event at", self.src.tell()
+                controller = bits_of(tail, 14, 2)
+                value = bits_of(tail, 16, 16)
+                print "Extended Controller ", part, controller, value, self.src.tell()
+            elif t4 == T4_ENOTE:
+                tail = self.src.readb(4)
+                part = bits_of(command, 12, 4)
+                pitch = bits_of(command, 15, 17)
+                if bits_of(tail, 2, 0) != 2:
+                    raise MusicError, "Failed QTMA validity check: Enote Event at", self.src.tell()
+                velocity = bits_of(tail, 7, 3)
+                duration = bits_of(tail, 22, 10)
+                self.qtma_commands.append(["enote",part,pitch,velocity,duration])
+            elif t3 == T3_MARKER: # Marker, not needed?  not using; can use rests/notes/enotes to increment time, no need for markers
+                subtype = bits_of(command, 8, 8)
+                value = bits_of(command, 16, 16)
+                if subtype == MARK_END:
+                    print "Marker: END " ,value, self.src.tell()
+                elif subtype == MARK_BEAT:
+                    print  "Marker: BEAT " ,value, self.src.tell()
+                elif subtype == MARK_TEMPO:
+                    print "Marker: TEMPO " ,value, self.src.tell()
                 else:
-                    self.parts[i] = 1
-                self.channels[i] = 1
-        self.load_qtma()
-    def setup_pygame_midi_output(self, output):
-        "Set up the MIDI output to play this music."
-        for partnumber,instrument in self.parts.items():
-            if instrument > 0x80: instrument &= 0x7F 
-            output.set_instrument(instrument,partnumber)
-    def load_qtma(self):
-        # Load the body commands
-        while not self.src.eof():
-            command = self.src.readb(4)
-            if   bits_of(command, 3, 0) == 1: # note event
+                    print "Unsupported Marker Event subtype %d with value %d at %d"%(subtype,value,self.src.tell())
+            elif t3 == T3_CONTROL:
                 part = bits_of(command, 5, 3)
-                pitch = bits_of(command, 6,8) + 32
+                controller = bits_of(command, 8, 8)
+                value = bits_of(command, 16, 16)
+                if controller == CON_MOD:
+                    self.src.seek(self.src.tell()-2) # backup 2 bytes; easiest way to read fixed 16 bit float is with self.src functions
+                    new_value = self.src.read_fixed16() # modulation value, and cursor moved back up to 2 bytes; modulations tiny in Cythera
+                    self.qtma_commands.append(["mod",part,new_value,0,0])
+                elif controller == CON_PAN:
+                    new_value = (value - 256)/2 # scale from 256 - 512 to 0 - 127
+                    if new_value > 127:
+                        new_value = 127
+                    self.qtma_commands.append(["pan",part,new_value,0,0])
+                elif controller == CON_VOL: # global channel volume saved in 16.16 floating point
+                    self.src.seek(self.src.tell()-2) # backup 2 bytes; easiest way to read fixed 16 bit float is with self.src functions
+                    new_value = self.src.read_fixed16() # volume value, and cursor moved back up to 2 bytes
+                    self.qtma_commands.append(["vol",part,new_value,0,0])
+                elif controller == CON_PITCH: # QTMA uses 14-bit num for pitch bend, postive and negative fractional semitones, 7 bits each
+                    # QTMA spec doesn't explain at all, and this is quite different than standard midi pitch bend
+                    # HACK! Attempt to adjust value to expected output based on "Stairway" and Odemia tracks
+                    # Center on 0; if upper 7 is 0, assume positive; if upper 7's are 1, assume negative and scale from positive value
+                    # In actuality, there's undoubtedly a function mapping the binary representation through fractional semitones to the pitch bend
+                    # TODO: Decode actual QTMA pitch bend value based on fractional semitones and replace hack
+                    # An additional note - this isn't too serious since the pitch bends are tiny fractions of a semitone in Cythera
+                    # Plus different synthesizers (including QT itself) will interpret differently over a wide range of full semitones
+                    # So the hack is sufficiently close to sound identical on pretty much any synthesizer
+                    MSB = bits_of(command,7,25) # MSB in last 7 bits like MIDI? 8th reserved in midi
+                    LSB = bits_of(command,7,17) # LSB in upper 7? minus reserved one like in midi
+                    if LSB != 0: # if non-zero, center and scale
+                        new_value = (MSB - 127)*7.4 # rough approximation of actual mapping function
+                    else:
+                        new_value = MSB # just use positive value directly
+                    self.qtma_commands.append(["pitch",part,int(new_value),0,0]) # ensure integer value
+                elif controller == CON_PRESS: # After touch or channel pressure; stripped from QT 2.0 and some other synths; tiny in Cythera anyways
+                    self.qtma_commands.append(["press",part,value,0,0])
+                elif controller == CON_SUSTAIN: # Damper pedal / sustain; binary value
+                    if value > 0: # any positive value is qtma for on
+                        new_value = 64 # midi for on
+                    else:
+                        new_value = 63 # midi for off
+                    self.qtma_commands.append(["sustain",part,new_value,0,0])
+                elif controller == CON_REVERB: # Effects 1 / Reverb
+                    new_value = bits_of(command,8,16) # qtma appears to only use the upper 8 bits of the value; not clear from docs
+                    self.qtma_commands.append(['reverb',part,new_value,0,0])
+                else:
+                    print "Unsupported Controller Event controller type %d for part %d with value %d at %d"%(controller,part,value,self.src.tell())
+            elif t3 == T3_NOTE:
+                part = bits_of(command, 5, 3)
+                pitch = bits_of(command, 6,8) + 32 # 32 bit offset in qtma
                 velocity = bits_of(command, 7, 14)
                 duration = bits_of(command, 11,21)
                 self.qtma_commands.append(["note",part,pitch,velocity,duration])
-            elif bits_of(command, 4, 0) == 9: # extended note
-               tail = self.src.readb(4)
-               part = bits_of(command, 12, 4)
-               pitch = bits_of(command, 15, 17)
-               velocity = bits_of(tail, 7, 3)
-               duration = bits_of(tail, 22, 10)
-               self.qtma_commands.append(["enote",part,pitch,velocity,duration])
-            elif bits_of(command, 3, 0) == 0: # rest 
+            elif t3 == T3_REST:
                 duration = bits_of(command, 24, 8)
                 self.qtma_commands.append(["rest",0,0,0,duration])
-            elif bits_of(command, 4, 0) == 15: # general
-                event_length = bits_of(command, 16, 16)
-                data_len = (event_length-2)*4
-                self.src.seek(data_len,1)
-            #else:
-            #    print "Unknown",("%02X "*4)%tuple(command), self.src.tell()
+            else:
+                print "Unknown event ",("%02X "*4)%tuple(command), self.src.tell()
+        # self.src.seek(body_offset)
+        # Before handling QTMA events, must ensure coherence of tracks for MIDI formatting; MIDI count needs to be consecutive
+        # Find the max track value, and make sure there are at least empty tracks to avoid track count errors with MIDI
+        for i in range(max(list(self.instruments))):
+            if i not in self.instruments:
+                if i > 0:
+                    self.instruments[i] = self.instruments[i-1] # If missing, fill in blank instrument with type next to it
+                else:
+                    self.instruments[i] = 1 # Default to standard piano
+                self.channels[i] = 1 # Channel doesn't matter
+        # self.load_qtma()
 
 
-        
+    def setup_pygame_midi_output(self, output):
+        "Set up the MIDI output to play this music."
+        for partnumber,instrument in self.instruments.items():
+            if instrument > 0x80: instrument &= 0x7F 
+            output.set_instrument(instrument,partnumber)
     def part(self,partnumber=None):
         """Return the general midi instrument associated with a part number."""
-        return self.parts if partnumber is None else self.parts[partnumber]
+        return self.instruments if partnumber is None else self.instruments[partnumber]
     def set_midi(self, new):
         self.midi_commands = new
         self.qtma_commands = []

--- a/examples/midi.py
+++ b/examples/midi.py
@@ -56,25 +56,40 @@ else: # archive
     musi = delv.sound.Music(resource.get_data())
 
 # Setup midi file
-midi = midiutil.MIDIFile(len(list(musi.parts)), file_format=1) # tracks equal to number of original parts; format=1 adds tempo track at 0
+midi = midiutil.MIDIFile(len(list(musi.instruments)), file_format=1) # tracks equal to number of original parts; format=1 adds tempo track at 0
 # May need to add an empty track if error occurs (like with 9005, Danger track), probably an error with the lib but unimportant
 
 # Tempo
-tempo_track = 0 # Tempo track always added as extra track at 0 in this format
+tempo_track = 0 # Tempo track always added as extra track at 0 in this format; bug in midiutil fixed as of v1.2.1 , tempo track correct with no other directives
 midi.addTempo(tempo_track, 0, 120)
 
 # Channels
 parts = list(musi.channels) # parts are 0-indexed, but with tempo track, must add offset
 time = 0
 for part in parts: # Setting instrument programs
-    midi.addProgramChange(part,musi.channels[part]-1,time,program=(musi.parts[part]-1)%127) # mod 127 used to ensure valid program nums (doesn't matter when channel 10 anyways)
+    midi.addProgramChange(part,musi.channels[part]-1,time,program=(musi.instruments[part]-1)%127) # mod 127 used to ensure valid program nums (doesn't matter when channel 10 anyways)
 
 # Notes, Extended Notes, and Rests
 for com in musi.qtma_commands:
     if com[0] == 'rest':
         time += com[4]/300.0 # 300 is the default length of a quarter note (1 beat) in QTMA, so we use that here to scale to the tempo (MIDI goes by beats, not QTMA intervals)
-    else:
+    elif com[0] == 'reverb':
+        midi.addControllerEvent(track=com[1],channel=musi.channels[com[1]]-1, time=time, controller_number=91, parameter=com[2])
+    elif com[0] == 'sustain':
+        midi.addControllerEvent(track=com[1],channel=musi.channels[com[1]]-1, time=time, controller_number=64, parameter=com[2])
+    elif com[0] == 'press':
+        midi.addChannelPressure(com[1], channel=musi.channels[com[1]]-1, time=time, pressure_value=com[2])
+    elif com[0] == 'pitch':
+        midi.addPitchWheelEvent(com[1], channel=musi.channels[com[1]]-1, time=time, pitchWheelValue=com[2])
+    elif com[0] == 'pan':
+        midi.addControllerEvent(track=com[1],channel=musi.channels[com[1]]-1, time=time, controller_number=10, parameter=com[2])
+    elif com[0] == 'vol':
+        midi.addControllerEvent(track=com[1],channel=musi.channels[com[1]]-1, time=time, controller_number=7, parameter=com[2])
+    elif com[0] == 'mod':
+        midi.addControllerEvent(track=com[1],channel=musi.channels[com[1]]-1, time=time, controller_number=1, parameter=com[2])
+    elif com[0] == 'note' or com[0] == 'enote':
         midi.addNote(com[1],channel=musi.channels[com[1]]-1,pitch=com[2],time=time,duration=com[4]/300.0,volume=com[3])
+
 
 
 # Write the resulting midi file

--- a/examples/midi.py
+++ b/examples/midi.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python
+# Copyright 2015 Bryce Schroeder, www.bryce.pw, bryce.schroeder@gmail.com
+# Wiki: http://www.ferazelhosting.net/wiki/delv
+# 
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# "Cythera" and "Delver" are trademarks of either Glenn Andreas or 
+# Ambrosia Software, Inc. 
+
+import delv
+import delv.archive
+import delv.sound
+import sys
+
+import midiutil
+
+USAGE = '''
+NOT FULLY IMPLEMENTED.
+
+Usage: ./midi.py archive resid 
+Or:    ./midi.py file 
+
+Converts a Delver music resource (QTMA) to standard MIDI (SMF)
+
+Requires midiutil.
+Using delv Version: %s
+'''%delv.version
+
+
+
+if len(sys.argv)<2:
+    print >> sys.stderr, USAGE
+    sys.exit(-1)
+
+source = open(sys.argv[1],'rb')
+
+if len(sys.argv)<3: # individual file
+    data = source.read()
+    musi = delv.sound.Music(data)
+else: # archive
+    resource = delv.archive.Scenario(source).get(int(sys.argv[2],16))
+    if not resource:
+        print >> sys.stderr, "No resource", sys.argv[2], "found in that archive."
+        sys.exit(-1)
+    musi = delv.sound.Music(resource.get_data())
+
+# Setup midi file
+midi = midiutil.MIDIFile(len(list(musi.parts)), file_format=1) # tracks equal to number of original parts; format=1 adds tempo track at 0
+# May need to add an empty track if error occurs (like with 9005, Danger track), probably an error with the lib but unimportant
+
+# Tempo
+tempo_track = 0 # Tempo track always added as extra track at 0 in this format
+midi.addTempo(tempo_track, 0, 120)
+
+# Channels
+parts = list(musi.channels) # parts are 0-indexed, but with tempo track, must add offset
+time = 0
+for part in parts: # Setting instrument programs
+    midi.addProgramChange(part,musi.channels[part]-1,time,program=(musi.parts[part]-1)%127) # mod 127 used to ensure valid program nums (doesn't matter when channel 10 anyways)
+
+# Notes, Extended Notes, and Rests
+for com in musi.qtma_commands:
+    if com[0] == 'rest':
+        time += com[4]/300.0 # 300 is the default length of a quarter note (1 beat) in QTMA, so we use that here to scale to the tempo (MIDI goes by beats, not QTMA intervals)
+    else:
+        midi.addNote(com[1],channel=musi.channels[com[1]]-1,pitch=com[2],time=time,duration=com[4]/300.0,volume=com[3])
+
+
+### Hack to Fix Program Changes!
+# midiutil has a bug with this format, sets directives to track 0, even though it's only the tempo track
+# must correct the -1 offset on all program changes to make sure the tracks are correct
+for i in xrange(len(midi.tracks)-1,0,-1): # Move program changes down until reach 0 and clear
+    if i > 1: # Go until moving from tempo track
+        event = 0
+    else:
+        event = 1 # Program change comes after tempo setting on track 0
+    midi.tracks[i].eventList.insert(0,midi.tracks[i-1].eventList[event]) # Move down track
+    del midi.tracks[i-1].eventList[event] # Remove program change for next loop
+
+
+# Write the resulting midi file
+with open(sys.argv[1]+'.midi','wb') as output_file:
+    midi.writeFile(output_file)

--- a/examples/midi.py
+++ b/examples/midi.py
@@ -26,14 +26,13 @@ import sys
 import midiutil
 
 USAGE = '''
-NOT FULLY IMPLEMENTED.
-
 Usage: ./midi.py archive resid 
 Or:    ./midi.py file 
 
-Converts a Delver music resource (QTMA) to standard MIDI (SMF)
+Converts a Delver music resource (90xx) from QuickTime Music
+Architecture (QTMA) format to Standard MIDI Format (SMF)
 
-Requires midiutil.
+Requires midiutil v1.2.1 or better for support of all events
 Using delv Version: %s
 '''%delv.version
 
@@ -43,7 +42,8 @@ if len(sys.argv)<2:
     print >> sys.stderr, USAGE
     sys.exit(-1)
 
-source = open(sys.argv[1],'rb')
+filename = sys.argv[1]
+source = open(filename,'rb')
 
 if len(sys.argv)<3: # individual file
     data = source.read()
@@ -61,7 +61,7 @@ midi = midiutil.MIDIFile(len(list(musi.instruments)), file_format=1) # tracks eq
 
 # Tempo
 tempo_track = 0 # Tempo track always added as extra track at 0 in this format; bug in midiutil fixed as of v1.2.1 , tempo track correct with no other directives
-midi.addTempo(tempo_track, 0, 120)
+midi.addTempo(tempo_track, 0, 120) # QT prefers 60 bpm, but SMF default is 120, which has much better support on most synths
 
 # Channels
 parts = list(musi.channels) # parts are 0-indexed, but with tempo track, must add offset
@@ -93,5 +93,6 @@ for com in musi.qtma_commands:
 
 
 # Write the resulting midi file
-with open(sys.argv[1]+'.midi','wb') as output_file:
+with open(filename+'.midi','wb') as output_file:
     midi.writeFile(output_file)
+

--- a/examples/midi.py
+++ b/examples/midi.py
@@ -77,18 +77,6 @@ for com in musi.qtma_commands:
         midi.addNote(com[1],channel=musi.channels[com[1]]-1,pitch=com[2],time=time,duration=com[4]/300.0,volume=com[3])
 
 
-### Hack to Fix Program Changes!
-# midiutil has a bug with this format, sets directives to track 0, even though it's only the tempo track
-# must correct the -1 offset on all program changes to make sure the tracks are correct
-for i in xrange(len(midi.tracks)-1,0,-1): # Move program changes down until reach 0 and clear
-    if i > 1: # Go until moving from tempo track
-        event = 0
-    else:
-        event = 1 # Program change comes after tempo setting on track 0
-    midi.tracks[i].eventList.insert(0,midi.tracks[i-1].eventList[event]) # Move down track
-    del midi.tracks[i-1].eventList[event] # Remove program change for next loop
-
-
 # Write the resulting midi file
 with open(sys.argv[1]+'.midi','wb') as output_file:
     midi.writeFile(output_file)


### PR DESCRIPTION
These changes update sound.py to handle general QTMA to MIDI conversion with support for all core QTMA commands.  An included example script shows how midiutil may be used to create MIDI files from the QTMA command list.